### PR TITLE
implement create conversation mutation

### DIFF
--- a/server/src/schema/ConversationType.js
+++ b/server/src/schema/ConversationType.js
@@ -19,17 +19,13 @@ export const ConversationResolvers = {
       parent,
       { input: { topic, userIds } },
       { services: { conversationService } }
-    ) => {
-      return conversationService.createConversation(topic, userIds);
-    },
+    ) => conversationService.createConversation(topic, userIds),
   },
 
   Conversation: {
     id: conversation => conversation.id,
     messages: () => [],
-    users: (conversation, args, { services }) =>
-      conversation.users.map(user =>
-        services.userService.fetchUserById(user.id)
-      ),
+    users: (conversation, args, { services: { conversationService } }) =>
+      conversationService.fetchUsersByConversationId(conversation.id),
   },
 };

--- a/server/src/schema/ConversationType.js
+++ b/server/src/schema/ConversationType.js
@@ -1,17 +1,35 @@
 import { gql } from 'apollo-server';
 
 export const ConversationType = gql`
+  extend type Mutation {
+    createConversation(input: NewConversationInput!): NewConversationPayload!
+  }
+
   type Conversation {
     id: ID!
+    topic: String!
     messages: [Message!]!
     users: [User!]!
   }
 `;
 
 export const ConversationResolvers = {
+  Mutation: {
+    createConversation: (
+      parent,
+      { input: { topic, userIds } },
+      { services: { conversationService } }
+    ) => {
+      return conversationService.createConversation(topic, userIds);
+    },
+  },
+
   Conversation: {
-    id: () => '1',
+    id: conversation => conversation.id,
     messages: () => [],
-    users: () => [],
+    users: (conversation, args, { services }) =>
+      conversation.users.map(user =>
+        services.userService.fetchUserById(user.id)
+      ),
   },
 };

--- a/server/src/schema/NewConversationInputType.js
+++ b/server/src/schema/NewConversationInputType.js
@@ -1,0 +1,8 @@
+import { gql } from 'apollo-server';
+
+export const NewConversationInputType = gql`
+  input NewConversationInput {
+    topic: String!
+    userIds: [ID!]!
+  }
+`;

--- a/server/src/schema/NewConversationPayloadType.js
+++ b/server/src/schema/NewConversationPayloadType.js
@@ -1,0 +1,7 @@
+import { gql } from 'apollo-server';
+
+export const NewConversationPayloadType = gql`
+  type NewConversationPayload {
+    conversation: Conversation!
+  }
+`;

--- a/server/src/schema/UserType.js
+++ b/server/src/schema/UserType.js
@@ -42,7 +42,8 @@ export const UserResolvers = {
   },
 
   User: {
-    id: (user, args, context) => user.id,
-    conversations: () => [],
+    id: user => user.id,
+    conversations: (user, args, context) =>
+      context.services.userService.fetchConversationsByUserId(user.id),
   },
 };

--- a/server/src/schema/__tests__/UserType.test.js
+++ b/server/src/schema/__tests__/UserType.test.js
@@ -1,10 +1,10 @@
 import { UserResolvers } from '../UserType';
 
 describe('UserResolvers', () => {
-  const { Query, User } = UserResolvers;
+  const { Query } = UserResolvers;
 
   describe('Query', () => {
-    const { currentUser, user, users } = Query;
+    const { currentUser } = Query;
 
     describe('currentUser', () => {
       it('returns null', () => {

--- a/server/src/schema/index.js
+++ b/server/src/schema/index.js
@@ -1,3 +1,5 @@
+import { merge } from 'lodash';
+
 // Root Types
 import { RootQueryType, RootQueryResolvers } from './QueryType.js';
 import { RootMutationType, RootMutationResolvers } from './MutationType.js';
@@ -10,6 +12,8 @@ import { UserLoginPayloadType } from './UserLoginPayloadType';
 
 // Conversation Types
 import { ConversationType, ConversationResolvers } from './ConversationType';
+import { NewConversationInputType } from './NewConversationInputType';
+import { NewConversationPayloadType } from './NewConversationPayloadType';
 
 // Message Types
 import { MessageType, MessageResolvers } from './MessageType';
@@ -27,23 +31,25 @@ export const typeDefs = [
 
   // Conversation Types
   ConversationType,
+  NewConversationInputType,
+  NewConversationPayloadType,
 
   // Message Types
   MessageType,
 ];
 
-export const resolvers = {
+export const resolvers = merge(
   // Root Resolvers
-  ...RootQueryResolvers,
-  ...RootMutationResolvers,
-  ...CustomScalarsResolvers,
+  RootQueryResolvers,
+  RootMutationResolvers,
+  CustomScalarsResolvers,
 
   // User Resolvers
-  ...UserResolvers,
+  UserResolvers,
 
   // Converation Resolvers
-  ...ConversationResolvers,
+  ConversationResolvers,
 
   // Message Resolvers
-  ...MessageResolvers,
-};
+  MessageResolvers
+);

--- a/server/src/services/conversation.js
+++ b/server/src/services/conversation.js
@@ -27,8 +27,6 @@ const createConversation = async (topic, userIds) => {
     conversation: {
       id: newConversation.id,
       topic: newConversation.topic,
-      users: userIds.map(id => ({ id })),
-      messages: [],
     },
   };
 };

--- a/server/src/services/conversation.js
+++ b/server/src/services/conversation.js
@@ -1,15 +1,16 @@
 import db from '../db';
 
-const addUserToConversation = (conversationId, userId) =>
-  db.query(
+const addUserToConversation = async (conversationId, userId) =>
+  await db.query(
     `INSERT INTO users_conversations (conversation_id, user_id)
-      VALUES ($1, $2)`,
+    VALUES ($1, $2)`,
     [parseInt(conversationId, 10), parseInt(userId, 10)]
   );
 
 const createConversation = async (topic, userIds) => {
   const response = await db.query(
-    `INSERT INTO conversations (topic, created_time) VALUES ($1, NOW())
+    `INSERT INTO conversations (topic, created_time) 
+    VALUES ($1, NOW())
     RETURNING id, topic`,
     [topic]
   );
@@ -19,9 +20,7 @@ const createConversation = async (topic, userIds) => {
   // TODO: (maybe) - This approach is not ideal,
   // since it makes many calls to the DB instead of one
   await Promise.all(
-    userIds.map(userId => {
-      addUserToConversation(newConversation.id, userId);
-    })
+    userIds.map(userId => addUserToConversation(newConversation.id, userId))
   );
 
   return {
@@ -34,4 +33,19 @@ const createConversation = async (topic, userIds) => {
   };
 };
 
-export default { createConversation };
+const fetchUsersByConversationId = async conversationId => {
+  const dbResponse = await db.query(
+    `SELECT 
+      uc.user_id AS id, 
+      u.username, 
+      u.email 
+    FROM users AS u
+    INNER JOIN users_conversations AS uc ON u.id = uc.user_id 
+    WHERE uc.conversation_id = $1`,
+    [conversationId]
+  );
+
+  return dbResponse.rows;
+};
+
+export default { createConversation, fetchUsersByConversationId };

--- a/server/src/services/conversation.js
+++ b/server/src/services/conversation.js
@@ -27,6 +27,7 @@ const createConversation = async (topic, userIds) => {
   return {
     conversation: {
       id: newConversation.id,
+      topic: newConversation.topic,
       users: userIds.map(id => ({ id })),
       messages: [],
     },

--- a/server/src/services/user.js
+++ b/server/src/services/user.js
@@ -38,4 +38,24 @@ const fetchUserById = async id => {
   return data.rows[0];
 };
 
-export default { createUser, createToken, fetchUsers, fetchUserById };
+const fetchConversationsByUserId = async userId => {
+  const dbResponse = await db.query(
+    `SELECT 
+      uc.conversation_id AS id, 
+      c.topic
+    FROM conversations AS c
+    INNER JOIN users_conversations AS uc ON c.id = uc.conversation_id 
+    WHERE uc.user_id = $1`,
+    [userId]
+  );
+
+  return dbResponse.rows;
+};
+
+export default {
+  createUser,
+  createToken,
+  fetchUsers,
+  fetchUserById,
+  fetchConversationsByUserId,
+};

--- a/server/src/services/user.js
+++ b/server/src/services/user.js
@@ -16,8 +16,8 @@ const createUser = async (username, email, password) => {
   const passwordHash = await generatePasswordHash(password);
 
   const result = await db.query(
-    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) \
-    RETURNING id, username, email',
+    `INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3)
+    RETURNING id, username, email`,
     [username, email, passwordHash]
   );
 


### PR DESCRIPTION
Closes #10 

This PR implements the `createConversation` mutation, and allows a caller to create a new conversation. 

Potential follow up/validation needed - make sure that we are not adding the same user to a conversation they are already in. (i.e. `createConversation(topic: 'hello', userIds: [1, 1, 1, 1, 1, 1])`)