### PR TITLE
bump apollo server version to fix security vulnerability

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1993,9 +1993,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.4.tgz",
-      "integrity": "sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
       "requires": {
         "@types/node": "*"
       }
@@ -2248,12 +2248,12 @@
       }
     },
     "apollo-server": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.14.1.tgz",
-      "integrity": "sha512-CjrVp7ZEowlEgtDi+H4ttN6nyHzhxSxUOeHQQMnRs+OxDwwphfgpXhATxz1+iHAecVro+8zxEzJtXFxPRRdUow==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.14.2.tgz",
+      "integrity": "sha512-H+X3HprWGxV8DIhQyXzheMheKRxSlD9/lMuzIHyW/7VPspc7rX0xsHaFcTwQGcxLz18LhM+HtMBtvzi/KlRIbA==",
       "requires": {
-        "apollo-server-core": "^2.14.1",
-        "apollo-server-express": "^2.14.1",
+        "apollo-server-core": "^2.14.2",
+        "apollo-server-express": "^2.14.2",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
@@ -2268,9 +2268,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.1.tgz",
-      "integrity": "sha512-Uk/jJwLtm+5YvExghNoq9V2ZHJRXPfaVOt4cIyo+mcjWG6YymHhMg5h9pR/auz9HMI8NP7ykmfo/bsTR1qutWQ==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.14.2.tgz",
+      "integrity": "sha512-8G6Aoz+k+ecuQco1KNLFbMrxhe/8uR4AOaOYEvT/N5m/6lrkPYzvBAxbpRIub5AxEwpBPcIrI452rR3PD9DItA==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.24",
@@ -2311,9 +2311,9 @@
       "integrity": "sha512-7oEd6pUxqyWYUbQ9TA8tM0NU/3aGtXSEibo6+txUkuHe7QaxfZ2wHRp+pfT1LC1K3RXYjKj61/C2xEO19s3Kdg=="
     },
     "apollo-server-express": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.14.1.tgz",
-      "integrity": "sha512-Ee1Oc+lzKfHh3BkDNRJL4s7Nnx+Nkmz606TBDi0ETSuNjJqXBNDbDM/YLS3LP7zJ5Oa37U7py72x8rrkPiZZNg==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.14.2.tgz",
+      "integrity": "sha512-iYyZm0kQqkM561i9l0WC9HbJsGZJbHP9bhnWaa1Itd+yNBS2AJFp6mRR3hQacsWXUw7ewaKAracMIggvfSH5Aw==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
@@ -2321,7 +2321,7 @@
         "@types/cors": "^2.8.4",
         "@types/express": "4.17.4",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.14.1",
+        "apollo-server-core": "^2.14.2",
         "apollo-server-types": "^0.5.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "apollo-server": "^2.14.1",
+    "apollo-server": "^2.14.2",
     "bcrypt": "^4.0.1",
     "core-js": "^3.6.5",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
There was a vulnerability in the version of Apollo Server we were using. Although there was literally no risk for our application at this point, it was also painless to update to the latest version. 

Full details: https://github.com/advisories/GHSA-w42g-7vfc-xf37

This PR just updates the version of Apollo Server to version 2.14.2