### PR TITLE
add mockedProvider to failing unit test

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,16 @@
         "tslib": "^1.10.0"
       }
     },
+    "@apollo/react-testing": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.4.tgz",
+      "integrity": "sha512-1eKjN36UfIAnBVmfLbl12vQ/eCjTqYdaU95chGIQzT2uHd5BnasJu0z+MwXBrEs57A9WY9mFvLZxdjzQJXaacA==",
+      "requires": {
+        "@apollo/react-common": "^3.1.4",
+        "fast-json-stable-stringify": "^2.0.0",
+        "tslib": "^1.10.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
+    "@apollo/react-testing": "^3.1.4",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useQuery } from '@apollo/react-hooks';
 import { gql } from 'apollo-boost';
 
-const TEST_QUERY = gql`
+export const TEST_QUERY = gql`
   {
     users {
       id

--- a/client/src/components/__tests__/App.test.js
+++ b/client/src/components/__tests__/App.test.js
@@ -1,10 +1,40 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import App from '../App';
+import { MockedProvider } from '@apollo/react-testing';
+import App, { TEST_QUERY } from '../App';
+
+const mocks = [
+  {
+    request: {
+      query: TEST_QUERY,
+    },
+    result: {
+      data: {
+        users: [
+          {
+            id: '1',
+            email: 'hello@goodbye.com',
+            username: 'stuffnthings',
+          },
+          {
+            id: '2',
+            email: 'goodbye@hello.com',
+            username: 'thingsnstuff',
+          },
+        ],
+      },
+    },
+  },
+];
 
 describe('App', () => {
   it('renders hello world', () => {
-    const { getByText } = render(<App />);
+    const { getByText } = render(
+      <MockedProvider mock={mocks} addTypename={false}>
+        <App />
+      </MockedProvider>
+    );
+
     const componentText = getByText('Hello World!');
     expect(componentText).toBeInTheDocument();
   });


### PR DESCRIPTION
This PR fixes an issue from before CI setup where the test app was not wrapped in an apollo provider, so the useQuery was bailing out. 